### PR TITLE
Optimize startup

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -202,6 +202,10 @@ void Dialog::readPacmanLogFile(const QString &logFile)
         oldPkg = pkg;
         oldVer = ver;
 
+        names.append(pkg);
+
+#define PARSE_TIME 0 // QDateTime operations are very slow and are not useful in the current implementation
+#if PARSE_TIME
         const int T_ix = timestamp.indexOf("T");
         if (T_ix != -1){
             // New-style timestamp yyyy-MM-ddThh:mm:ss-zzzz. Strip offset and replace
@@ -217,10 +221,12 @@ void Dialog::readPacmanLogFile(const QString &logFile)
         }
 
         const QDateTime datetime = QDateTime::fromString(timestamp, "yyyy-MM-dd hh:mm:ss");
-
-        names.append(pkg);
-
         query.bindValue( ":date", datetime.toString("yyyy-MM-dd") );
+#else
+        timestamp.truncate(10); // leave only yyyy-MM-dd in timestamp
+        query.bindValue( ":date", timestamp );
+#endif
+
         query.bindValue( ":op", op );
         query.bindValue( ":pkg", pkg );
         query.bindValue( ":ver", ver );

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -25,6 +25,7 @@
 #include "datecolumndelegate.h"
 #include "actioncolumndelegate.h"
 
+#include <QElapsedTimer>
 #include <QSqlTableModel>
 #include <QDebug>
 
@@ -168,7 +169,10 @@ void Dialog::readPacmanLogFile(const QString &logFile)
         qDebug() << "can't open log file : " << file.errorString();
         return;
     }
-    
+
+    QElapsedTimer timer;
+    timer.start();
+
     QSqlQuery query("DELETE FROM log");
     query.exec();
 
@@ -238,6 +242,8 @@ void Dialog::readPacmanLogFile(const QString &logFile)
     
     ui->tableView->hideColumn(0);
     ui->tableView->show();
+
+    qDebug() << "readPacmanLogFile() took" << timer.elapsed() << "ms";
 }
 
 void Dialog::applyFilters()

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -26,8 +26,13 @@
 #include "actioncolumndelegate.h"
 
 #include <QSqlTableModel>
-#include <QtWidgets>
 #include <QDebug>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+#include <QtWidgets>
+#else
+#include <QtGui>
+#endif
 
 Dialog::Dialog(QWidget *parent) :
     QDialog(parent),

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -175,6 +175,7 @@ void Dialog::readPacmanLogFile(const QString &logFile)
 
     QSqlQuery query("DELETE FROM log");
     query.exec();
+    query.prepare("INSERT INTO log (date,op,pkg,ver) VALUES(:date, :op, :pkg, :ver)");
 
     QStringList names;
     QString oldPkg;
@@ -219,7 +220,6 @@ void Dialog::readPacmanLogFile(const QString &logFile)
 
         names.append(pkg);
 
-        query.prepare("INSERT INTO log (date,op,pkg,ver) VALUES(:date, :op, :pkg, :ver)");
         query.bindValue( ":date", datetime.toString("yyyy-MM-dd") );
         query.bindValue( ":op", op );
         query.bindValue( ":pkg", pkg );


### PR DESCRIPTION
This pull request speeds up the slowest function called at Pacman Log Viewer start from 6.1 to 0.85 seconds on my system (pacman.log size is about 14 MiB).

See the commit messages for details.